### PR TITLE
add extendedglob option to toml parsing

### DIFF
--- a/functions/@str-read-toml
+++ b/functions/@str-read-toml
@@ -27,6 +27,8 @@
 #
 
 @str-read-toml() {
+  emulate -LR zsh -o extendedglob -o warncreateglobal -o typesetsilent
+
   local __toml_file="$1" __out_hash="${2:-TOML}" __key_prefix="$3"
   local IFS='' __line __cur_section="void" __access_string REPLY
   local -a match mbegin mend


### PR DESCRIPTION
toml reading failed for me until - reading the code - i figured that i didn't have extendedglob set. looking at the other functions, i added this line and now i can use @str-read-toml.