### PR TITLE
ci(trunk): refresh caller workflow

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -1,14 +1,28 @@
 ---
-name: "⭕ Trunk"
+name: Trunk Code Quality
+
 on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
-    name: "⚡"
+    name: Trunk Code Quality
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     uses: z-shell/.github/.github/workflows/trunk.yml@main
+    with:
+      arguments: --no-progress


### PR DESCRIPTION
## Summary

- Update the Trunk caller workflow to the refreshed org-level single-job shape from z-shell/.github#404.
- Add explicit permissions, concurrency, and `arguments: --no-progress`.

Part of z-shell/.github#408.

## Verification

- Workflow-only change to `.github/workflows/trunk-check.yml`.
- YAML shape reviewed after writing the workflow.

## Agent handoff

**Status:** Ready for review
**Current state:** PR contains only the Trunk caller refresh.
**Blockers:** None known.
**Next steps:** Wait for PR CI; merge if green.