### PR TITLE
fix(makefile): point zunit install hint to z-shell/zunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ check: test
 test:
 	@command -v zunit >/dev/null && \
 		{ zunit; ((1)); } || \
-		echo "Please install zunit to run the tests (https://github.com/zdharma/zunit)"
+		echo "Please install zunit to run the tests (https://github.com/z-shell/zunit)"


### PR DESCRIPTION
The `test` target's install hint pointed at the retired `zdharma/zunit`. zunit now lives at `z-shell/zunit`. (ZSH-13)